### PR TITLE
Implement Rumble on SDL2 based gamepads

### DIFF
--- a/Source/OpenTK/Input/IJoystickDriver2.cs
+++ b/Source/OpenTK/Input/IJoystickDriver2.cs
@@ -34,5 +34,6 @@ namespace OpenTK.Input
         JoystickState GetState(int index);
         JoystickCapabilities GetCapabilities(int index);
         Guid GetGuid(int index);
+        bool SetVibration(int index, float left, float right);
     }
 }

--- a/Source/OpenTK/Input/Joystick.cs
+++ b/Source/OpenTK/Input/Joystick.cs
@@ -92,5 +92,18 @@ namespace OpenTK.Input
         //{
         //    return implementation.GetName(index);
         //}
+
+
+        /// <summary>
+        /// Sets the vibration on the device.
+        /// </summary>
+        /// <param name="index">The zero-based index of the device to poll.</param>
+        /// <param name="left">The strength of the left or low frequency motor (0 to 1).</param>
+        /// <param name="right">The strength of the right or high frequency motor (0 to 1).</param>
+        /// <returns></returns>
+        public static bool SetVibration(int index, float left, float right)
+        {
+            return implementation.SetVibration(index, left, right);
+        }
     }
 }

--- a/Source/OpenTK/Platform/Linux/LinuxJoystick.cs
+++ b/Source/OpenTK/Platform/Linux/LinuxJoystick.cs
@@ -472,5 +472,10 @@ namespace OpenTK.Platform.Linux
             }
             return Guid.Empty;
         }
+
+        public bool SetVibration(int index, float left, float right)
+        {
+            return false;
+        }
     }
 }

--- a/Source/OpenTK/Platform/MacOS/HIDInput.cs
+++ b/Source/OpenTK/Platform/MacOS/HIDInput.cs
@@ -1678,6 +1678,11 @@ namespace OpenTK.Platform.MacOS
             GC.SuppressFinalize(this);
         }
 
+        public bool SetVibration(int index, float left, float right)
+        {
+            return false;
+        }
+
         ~HIDInput()
         {
             Dispose(false);

--- a/Source/OpenTK/Platform/MappedGamePadDriver.cs
+++ b/Source/OpenTK/Platform/MappedGamePadDriver.cs
@@ -240,7 +240,7 @@ namespace OpenTK.Platform
 
         public bool SetVibration(int index, float left, float right)
         {
-            return false;
+            return Joystick.SetVibration(index, left, right);
         }
 
         private GamePadConfiguration GetConfiguration(Guid guid)

--- a/Source/OpenTK/Platform/SDL2/Sdl2.cs
+++ b/Source/OpenTK/Platform/SDL2/Sdl2.cs
@@ -37,13 +37,13 @@ namespace OpenTK.Platform.SDL2
 
     internal partial class SDL
     {
-        #if ANDROID
+#if ANDROID
         const string lib = "libSDL2.so";
-        #elif IPHONE
+#elif IPHONE
         const string lib = "__Internal";
-        #else
+#else
         private const string lib = "SDL2.dll";
-        #endif
+#endif
 
         public readonly static object Sync = new object();
         private static Nullable<Version> version;
@@ -335,6 +335,15 @@ namespace OpenTK.Platform.SDL2
         }
 
         [SuppressUnmanagedCodeSecurity]
+        [DllImport(lib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_JoystickRumble", ExactSpelling = true)]
+        public static extern int JoystickRumble(
+            IntPtr joystick,
+            UInt16 low_frequency_rumble,
+            UInt16 high_frequency_rumble,
+            UInt32 duration_ms
+            );
+
+        [SuppressUnmanagedCodeSecurity]
         [DllImport(lib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_JoystickNumAxes", ExactSpelling = true)]
         public static extern int JoystickNumAxes(IntPtr joystick);
 
@@ -394,7 +403,7 @@ namespace OpenTK.Platform.SDL2
 
             unsafe
             {
-                fixed (Event *pe = e)
+                fixed (Event* pe = e)
                 {
                     return PeepEvents(pe, count, action, min, max);
                 }
@@ -1597,12 +1606,12 @@ namespace OpenTK.Platform.SDL2
         public enum EventType : uint
         {
             /* Touch events */
-            FingerDown      = 0x700,
+            FingerDown = 0x700,
             FingerUp,
             FingerMotion,
 
             /* Gesture events */
-            DollarGesture   = 0x800,
+            DollarGesture = 0x800,
             DollarRecord,
             MultiGesture,
         }

--- a/Source/OpenTK/Platform/SDL2/Sdl2JoystickDriver.cs
+++ b/Source/OpenTK/Platform/SDL2/Sdl2JoystickDriver.cs
@@ -594,7 +594,16 @@ namespace OpenTK.Platform.SDL2
 
         public bool SetVibration(int index, float left, float right)
         {
-            return false;
+            var device_id = sdl_instanceid_to_joysticks[index];
+            var joystick_device = (JoystickDevice< Sdl2JoystickDetails>)joysticks[device_id];
+
+            var res = SDL.JoystickRumble(
+                joystick_device.Details.Handle,
+                (ushort)(65535f * left), (ushort)(65535f * right),
+                1000000U
+                );
+
+            return res == 0;
         }
 #endif
 

--- a/Source/OpenTK/Platform/Windows/WinRawJoystick.cs
+++ b/Source/OpenTK/Platform/Windows/WinRawJoystick.cs
@@ -914,5 +914,10 @@ namespace OpenTK.Platform.Windows
                 return new Guid();
             }
         }
+
+        public bool SetVibration(int index, float left, float right)
+        {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Hey there :wave: 

This PR adds controller vibration support for XInput, DualShock and Nintendo Switch Pro controllers when using the SDL2 backend. It adds `SetVibration` to the `IJoystickDriver2` Interface which is implemented in `Sdl2JoystickDriver`. Method stubs for other classes that derive from `IJoystickDriver2` are also added but they just return false for now. 

SDL version 2.0.9 or higher is required for it to work!